### PR TITLE
Add RLC 2025

### DIFF
--- a/_conferences/rlc-2025.md
+++ b/_conferences/rlc-2025.md
@@ -1,0 +1,10 @@
+---
+name: "The 2nd Reinforcement Learning Conference (RLC)"
+website: https://rl-conference.cc
+location: Edmonton, AB, Canada
+online: false
+lang: English
+
+date_start: 2025-08-05
+date_end:   2025-08-08
+---


### PR DESCRIPTION
RLC provides a venue where reinforcement learning researchers can interact and share their research in a more focused setting than typical large machine learning venues.